### PR TITLE
Readme update

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ If running against an active identity management service
 python manage.py runserver_ssl
 ```
 
-## Quickstart - running sue-my-brother agaist local instance of dex
+## Quickstart - running sue-my-brother against local instance of dex
 
 ```
 git clone https://github.com/crossgovernmentservices/csd-identity-products.git

--- a/app/blueprints/base/views.py
+++ b/app/blueprints/base/views.py
@@ -85,6 +85,8 @@ def logout():
 def oidc_callback():
     user_info = oidc.authenticate('dex', request)
 
+    session["iat"] = user_info["iat"]
+
     user = user_datastore.get_user(user_info['email'])
 
     if not user:
@@ -105,7 +107,9 @@ def create_user(user_info):
     email = user_info['email']
 
     user = add_role('USER', user_datastore.create_user(
-        email=email))
+        email=email,
+        issuer_id=user_info["iss"],
+        subject_id=user_info["sub"]))
 
     user_datastore.commit()
 

--- a/lib/oidc_old.py
+++ b/lib/oidc_old.py
@@ -20,7 +20,7 @@ def verify_id_token(token, config):
     key = keys.get(header['kid'])
 
     if not key:
-        raise KeyNotFound()
+        raise KeyNotFound(header["kid"])
 
     return jwt.decode(token, key, audience=config['client_id'])
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,6 @@
+import contextlib
+import datetime
+import mock
 import os
 import subprocess
 
@@ -151,3 +154,14 @@ def unnamed_user_logged_in(unnamed_user, login):
 def logged_in(test_user, login):
     login(test_user)
     yield test_user
+
+
+@pytest.fixture
+def utcnow():
+    @contextlib.contextmanager
+    def patch_now(module, val):
+        with mock.patch(module) as dt:
+            dt.utcnow.return_value = val
+            dt.side_effect = datetime.datetime
+            yield
+    return patch_now

--- a/tests/test_oidc.py
+++ b/tests/test_oidc.py
@@ -1,0 +1,100 @@
+import datetime
+import pytest
+import mock
+from lib.oidc_old import verify_id_token
+from flask import session, url_for
+
+from app.blueprints.base.models import User
+
+
+test_token_response = {
+    'id_token': (
+        'eyJhbGciOiJSUzI1NiIsImtpZCI6IjRmYjE1NjVlYWRlNTFiOWMzYTUyYmU0ND'
+        'I0YjNjYTkxYzM4ZjUzNjUiLCJ0eXAiOiJKV1QifQ.eyJhdWQiOiI4cHJZb1p5bTB6a3Q2'
+        'WnpUSWJYYUZCUXZ0cldpMkE4eG1kQzlXRXozaTE0PUBsb2NhbGhvc3QiLCJlbWFpbCI6I'
+        'mtlbi50c2FuZ0BkaWdpdGFsLmNhYmluZXQtb2ZmaWNlLmdvdi51ayIsImVtYWlsX3Zlcm'
+        'lmaWVkIjp0cnVlLCJleHAiOjE0NzM4OTYzNjYsImlhdCI6MTQ3Mzg1MzE2NiwiaXNzIjo'
+        'iaHR0cDovL2RleC5leGFtcGxlLmNvbTo1NTU2IiwibmFtZSI6IiIsInN1YiI6IjZjN2E5'
+        'ZjQ1LTdmNTctNGQ5MS1iZTBlLTI4NjY3M2EyOGM2ZiJ9.tAVC2OD70vuTiARWoSagm37x'
+        'QcWZ3o8W9jLvW8mHG39MgOp6GHGhyJuTgvkciDqi10SqHMcaGH9jSZepVUkQBNYPKejp9'
+        'VZ3iiXyq731ckzoY93q5TvSOqjkoG7_HxXCkD5RX2F6XdTq_Se231TSEgWPxYl3ycLzKt'
+        'NMeD5o3Aq8z_ypzgl7kQmEEdZWPSAcQr7-6IIHJ38UgDZfPhTYtUB4f_abgXXcuQV10uW'
+        'kXBMdOzfM2s9ByexSAvL2-HVs_jtdC3C-Rwu_05yKfduVO5yiNBxoyrkv2yZgEhfKNh1W'
+        'LYj2cb08cs4iw4u8QSEOSEzL5Gy1wXPdL78aoaqUYg')}
+
+
+@pytest.fixture
+def claims(utcnow):
+    config = {
+        "client_id":
+            "8prYoZym0zkt6ZzTIbXaFBQvtrWi2A8xmdC9WEz3i14=@localhost",
+        "keys": [
+            {
+                "kid": "4fb1565eade51b9c3a52be4424b3ca91c38f5365",
+                "kty": "RSA",
+                "alg": "RS256",
+                "use": "sig",
+                "e": "AQAB",
+                "n": (
+                    "zzJAqac1b3GVEehBZUp48gjJpXkD-vGsFyeTmWJGl00NVmgimW-h7"
+                    "UUrVtJiwnaXS98D3ZPFnQRUrn1bmLeADkHs2sbWyfCNTYVK2sBY0Y"
+                    "K6AamIwCLEET8aWB2b0P6L7xpM8lP8y3ss42ICgWV73txv-KwI8Fw"
+                    "aDScIzSzSSdWWgqxh54PCMGAbWJCg6kjyufBocBVaZLUL_4HKIixI"
+                    "SgyThUpFYND8iaQThI6fkW5o3Qc95AEcm5XKvlEXYv-BWWj-xBXka"
+                    "FDy9YOjUKAXcYmWPhbY5LGM1GYk79PigNggxgRDsrxWDNQUzH25o8"
+                    "wxRfOX1cZ-bdVzGYHDYeUbpw=="
+                )
+            }
+        ]
+    }
+    now = datetime.datetime(2016, 9, 14, 12, 40)
+    with utcnow("jose.jwt.datetime", now):
+        claims = verify_id_token(test_token_response['id_token'], config)
+
+    return claims
+
+expected_issue_timestamp = 1473853166
+
+
+@pytest.yield_fixture
+def mock_auth(claims):
+    with mock.patch("app.blueprints.base.views.oidc") as oidc:
+        oidc.authenticate.return_value = claims
+        yield
+
+
+@pytest.yield_fixture
+def ds_spy():
+    with mock.patch("app.extensions.user_datastore") as ds:
+        ds.create_user = mock.Mock()
+        yield ds.create_user
+
+
+class WhenClientReceivesAnIDToken(object):
+
+    def it_contains_an_auth_time_claim(self, claims):
+        assert claims["iat"] == expected_issue_timestamp
+
+
+class WhenUserIsAuthenticated(object):
+
+    def it_stores_issuer_and_subject_id(self, mock_auth, client, db_session):
+
+        expected_claims = {
+            'email': 'ken.tsang@digital.cabinet-office.gov.uk',
+            'issuer_id': 'http://dex.example.com:5556',
+            'subject_id': '6c7a9f45-7f57-4d91-be0e-286673a28c6f'
+        }
+
+        response = client.get(url_for("base.oidc_callback"))
+        assert response.status_code == 302
+
+        users = User.query.filter_by(**expected_claims).all()
+        assert len(users) == 1
+
+    def it_is_possible_to_get_iat(self, mock_auth, client, db_session):
+
+        response = client.get(url_for("base.oidc_callback"))
+        assert response.status_code == 302
+
+        assert session['iat'] == expected_issue_timestamp

--- a/users.txt
+++ b/users.txt
@@ -4,3 +4,4 @@ tom.dolan@digital.cabinet-office.gov.uk,password,0,1
 colm.britton@digital.cabinet-office.gov.uk,password,1,1
 abisola.fatokun@digital.cabinet-office.gov.uk,password,0,0
 simon.everest@digital.cabinet-office.gov.uk,password,0,0
+ken.tsang@digital.cabinet-office.gov.uk,password,1,1


### PR DESCRIPTION
## What
- Updated views to store issuer id and subject id and save auth datetime value in a session
- Add tests for OIDC
## How to review
1. Install pytest
2. In sue-my-brother execute 

```
python manage.py test
```
## Who can review

Not @kentsanggds

Associated with 
- https://trello.com/c/FzjcrEuV 
- https://trello.com/c/KaZDx96T
