### PR TITLE
enable reauthentication when approving suits

### DIFF
--- a/app/blueprints/base/views.py
+++ b/app/blueprints/base/views.py
@@ -67,13 +67,11 @@ def sanitize_url(url):
 def authenticated_within(max_age):
     auth_time = session["iat"]
     time_elapsed_since_authenticated = int(time.time()) - auth_time
-    print("timeElapsed:" + str(time_elapsed_since_authenticated))
 
     return time_elapsed_since_authenticated <= max_age
 
 
 def force_authentication(path=None):
-    print("Force authentication")
     request_path = request.full_path
     if path is not None:
         request_path = path
@@ -296,20 +294,20 @@ def admin():
 @roles_required('admin')
 @accept_suit_permission.require()
 def accept(suit):
-    suitObj = Suit.query.get(suit)
+    suit_obj = Suit.query.get(suit)
 
     max_age = current_app.config.get("ACCEPT_SUIT_MAX_AGE")
     if not authenticated_within(max_age):
         return force_authentication()
 
-    suitObj.accepted = datetime.datetime.utcnow()
-    db.session.add(suitObj)
+    suit_obj.accepted = datetime.datetime.utcnow()
+    db.session.add(suit_obj)
     db.session.commit()
 
     notify['accept'].send_email(
-        suitObj.plaintiff.email,
-        plaintiff=suitObj.plaintiff.name,
-        defendant=suitObj.defendant.name)
+        suit_obj.plaintiff.email,
+        plaintiff=suit_obj.plaintiff.name,
+        defendant=suit_obj.defendant.name)
 
     flash('Suit accepted')
     return redirect(url_for('.admin'))

--- a/app/config.py
+++ b/app/config.py
@@ -72,7 +72,6 @@ if all(DB.values()):
 if 'DATABASE_URL' in env:
     SQLALCHEMY_DATABASE_URI = env.get('DATABASE_URL')
 
-# Authentication Max_age
 ACCEPT_SUIT_MAX_AGE = 300
 
 # XXX Don't change the following settings unless necessary

--- a/app/config.py
+++ b/app/config.py
@@ -72,6 +72,8 @@ if all(DB.values()):
 if 'DATABASE_URL' in env:
     SQLALCHEMY_DATABASE_URI = env.get('DATABASE_URL')
 
+# Authentication Max_age
+ACCEPT_SUIT_MAX_AGE = 300
 
 # XXX Don't change the following settings unless necessary
 

--- a/app/templates/admin/index.html
+++ b/app/templates/admin/index.html
@@ -59,5 +59,8 @@
   <div>
     <a href="{{ config["GOVUK_NOTIFY"]["service_url"] }}/services/{{ config["GOVUK_NOTIFY"]["client_id"] }}/dashboard">Update email and sms templates</a>
   </div>
+  <div>
+    <a href="{{ url_for('base.reauthenticate', caller='admin') }}">Reauthenticate</a>
+  </div>
 
 {% endblock %}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,7 +10,7 @@ import sqlalchemy
 
 from app.blueprints.base.models import User
 from app.config import SQLALCHEMY_DATABASE_URI
-from app.extensions import db as _db
+from app.extensions import db as _db, user_datastore
 from app.factory import create_app
 
 
@@ -122,6 +122,18 @@ def test_user(db_session):
 
 
 @pytest.fixture
+def test_admin_user(db_session):
+    admin = user_datastore.find_or_create_role('admin')
+    user = user_datastore.create_user(
+        email="admin@example.com",
+        roles=[admin],
+        is_superadmin=True,
+        can_accept_suits=True)
+    user_datastore.commit()
+    return user
+
+
+@pytest.fixture
 def unnamed_user(db_session):
     user = User(email='test@example.com', active=True)
     db_session.add(user)
@@ -154,6 +166,12 @@ def unnamed_user_logged_in(unnamed_user, login):
 def logged_in(test_user, login):
     login(test_user)
     yield test_user
+
+
+@pytest.yield_fixture
+def admin_logged_in(test_admin_user, login):
+    login(test_admin_user)
+    yield test_admin_user
 
 
 @pytest.fixture

--- a/tests/test_authentication.py
+++ b/tests/test_authentication.py
@@ -1,0 +1,137 @@
+import mock
+import pytest
+import time
+
+from datetime import datetime
+from flask import url_for
+from mock import Mock, patch
+
+from app.blueprints.base.models import User, Suit
+from app.blueprints.base.views import authenticated_within
+
+max_age = 50
+
+mock_time_more_than_max_age = Mock()
+mock_time_more_than_max_age.return_value = time.mktime(
+    datetime(2011, 6, 21, 10, 10, 0).timetuple())
+
+mock_time_less_than_max_age = Mock()
+mock_time_less_than_max_age.return_value = time.mktime(
+    datetime(2011, 6, 21, 10, 0, max_age - 5).timetuple())
+
+mock_session = Mock()
+mock_session = {'iat': time.mktime(
+    datetime(2011, 6, 21, 10, 0, 0).timetuple())}
+
+mock_openid_config = Mock()
+mock_openid_config.return_value = {'authorization_endpoint':
+                                   'http://dex.example.com:5556/auth',
+                                   'discovery_url':
+                                   'http://dex.example.com:5556',
+                                   'client_id': None}
+
+
+@pytest.yield_fixture
+def mock_views_current_app_config():
+    with mock.patch("app.blueprints.base.views.current_app") as current_app:
+        current_app.config.get.return_value = max_age
+        yield
+
+
+@pytest.yield_fixture
+def mock_oidc_current_app_config():
+    with mock.patch("lib.oidc_old.current_app") as current_app:
+        current_app.config.get.return_value = max_age
+        yield
+
+
+@pytest.yield_fixture
+def mock_notify():
+    with mock.patch("app.blueprints.base.views.notify") as notify:
+        notify.send_email.return_value = ""
+        yield
+
+
+@pytest.fixture
+def test_suit(db_session):
+    suit = Suit(
+        plaintiff=User(
+            email='plaintiff@example.com', name='Plaintiff Test', active=True
+        ),
+        defendant=User(
+            email='defendant@example.com', name='Defendant Test', active=True
+        )
+    )
+    db_session.add(suit)
+    db_session.commit()
+    return suit
+
+
+@pytest.fixture
+def post_accept_suit(client, test_suit):
+    return client.post(url_for('base.accept', suit=test_suit.id),
+                       follow_redirects=False)
+
+
+class WhenTimeSinceLastAuthenticatedIsMoreThanMaxAge(object):
+
+    @patch.dict('app.blueprints.base.views.session', mock_session)
+    @patch('time.time', mock_time_more_than_max_age)
+    def it_returns_false(self, client):
+
+        print(mock_session['iat'])
+        print(time.time())
+
+        assert authenticated_within(max_age) is False
+
+
+class WhenTimeSinceLastAuthenticatedIsLessThanMaxAge(object):
+
+    @patch.dict('app.blueprints.base.views.session', mock_session)
+    @patch('time.time', mock_time_less_than_max_age)
+    def it_returns_true(self, client):
+
+        print(mock_session['iat'])
+        print(time.time())
+
+        assert authenticated_within(max_age) is True
+
+
+class WhenAcceptingASuitWithinAuthenticatedTime(object):
+
+    @patch('time.time', mock_time_less_than_max_age)
+    def it_redirects_to_admin(self, test_admin_user, client, test_suit,
+                              mock_notify, mock_views_current_app_config):
+
+        with client.session_transaction() as session:
+            session['user_id'] = test_admin_user.id
+            session['_fresh'] = False
+            session['iat'] = mock_session['iat']
+
+        response = client.post(url_for('base.accept', suit=test_suit.id))
+
+        print(response.headers["Location"])
+        assert response.status_code == 302
+        assert ("/admin" in
+                response.headers["Location"])
+
+
+class WhenAcceptingASuitOutsideAuthenticatedTime(object):
+
+    @patch('lib.oidc_old.OIDC.openid_config', mock_openid_config)
+    @patch('time.time', mock_time_more_than_max_age)
+    def it_redirects_to_identity_broker(
+            self, test_admin_user, client, test_suit,
+            mock_oidc_current_app_config):
+
+        with client.session_transaction() as session:
+            session['user_id'] = test_admin_user.id
+            session['_fresh'] = False
+            session['iat'] = mock_session['iat']
+
+        response = client.post(url_for('base.accept', suit=test_suit.id))
+
+        print(response.headers["Location"])
+        assert response.status_code == 302
+        assert ("prompt=login" in
+                response.headers["Location"])

--- a/tests/test_authentication.py
+++ b/tests/test_authentication.py
@@ -122,6 +122,7 @@ class WhenAcceptingASuitOutsideAuthenticatedTime(object):
     @patch('time.time', mock_time_more_than_max_age)
     def it_redirects_to_identity_broker(
             self, test_admin_user, client, test_suit,
+            mock_views_current_app_config,
             mock_oidc_current_app_config):
 
         with client.session_transaction() as session:

--- a/tests/test_authentication.py
+++ b/tests/test_authentication.py
@@ -12,23 +12,24 @@ from app.blueprints.base.views import authenticated_within
 max_age = 50
 
 mock_time_more_than_max_age = Mock()
-mock_time_more_than_max_age.return_value = time.mktime(
-    datetime(2011, 6, 21, 10, 10, 0).timetuple())
+mock_time_more_than_max_age.return_value = (
+    time.mktime(datetime(2011, 6, 21, 10, 10, 0).timetuple()))
 
 mock_time_less_than_max_age = Mock()
-mock_time_less_than_max_age.return_value = time.mktime(
-    datetime(2011, 6, 21, 10, 0, max_age - 5).timetuple())
+mock_time_less_than_max_age.return_value = (
+    time.mktime(datetime(2011, 6, 21, 10, 0, max_age - 5).timetuple()))
 
 mock_session = Mock()
-mock_session = {'iat': time.mktime(
-    datetime(2011, 6, 21, 10, 0, 0).timetuple())}
+mock_session = {
+    'iat': time.mktime(datetime(2011, 6, 21, 10, 0, 0).timetuple())}
 
 mock_openid_config = Mock()
-mock_openid_config.return_value = {'authorization_endpoint':
-                                   'http://dex.example.com:5556/auth',
-                                   'discovery_url':
-                                   'http://dex.example.com:5556',
-                                   'client_id': None}
+mock_openid_config.return_value = {
+    'authorization_endpoint':
+    'http://dex.example.com:5556/auth',
+    'discovery_url':
+    'http://dex.example.com:5556',
+    'client_id': None}
 
 
 @pytest.yield_fixture
@@ -79,9 +80,6 @@ class WhenTimeSinceLastAuthenticatedIsMoreThanMaxAge(object):
     @patch('time.time', mock_time_more_than_max_age)
     def it_returns_false(self, client):
 
-        print(mock_session['iat'])
-        print(time.time())
-
         assert authenticated_within(max_age) is False
 
 
@@ -90,9 +88,6 @@ class WhenTimeSinceLastAuthenticatedIsLessThanMaxAge(object):
     @patch.dict('app.blueprints.base.views.session', mock_session)
     @patch('time.time', mock_time_less_than_max_age)
     def it_returns_true(self, client):
-
-        print(mock_session['iat'])
-        print(time.time())
 
         assert authenticated_within(max_age) is True
 
@@ -110,10 +105,8 @@ class WhenAcceptingASuitWithinAuthenticatedTime(object):
 
         response = client.post(url_for('base.accept', suit=test_suit.id))
 
-        print(response.headers["Location"])
         assert response.status_code == 302
-        assert ("/admin" in
-                response.headers["Location"])
+        assert "/admin" in response.headers["Location"]
 
 
 class WhenAcceptingASuitOutsideAuthenticatedTime(object):
@@ -132,7 +125,5 @@ class WhenAcceptingASuitOutsideAuthenticatedTime(object):
 
         response = client.post(url_for('base.accept', suit=test_suit.id))
 
-        print(response.headers["Location"])
         assert response.status_code == 302
-        assert ("prompt=login" in
-                response.headers["Location"])
+        assert "prompt=login" in response.headers["Location"]

--- a/tests/test_oidc.py
+++ b/tests/test_oidc.py
@@ -63,13 +63,6 @@ def mock_auth(claims):
         yield
 
 
-@pytest.yield_fixture
-def ds_spy():
-    with mock.patch("app.extensions.user_datastore") as ds:
-        ds.create_user = mock.Mock()
-        yield ds.create_user
-
-
 class WhenClientReceivesAnIDToken(object):
 
     def it_contains_an_auth_time_claim(self, claims):


### PR DESCRIPTION
## What
- if the elapsed time since last authenticated > ACCEPT_SUIT_MAX_AGE in config.py user is reauthenticated
- authentication tests created
## How to review
- Create a suit
- Log in as an admin user
- Wait more than 5 minutes (ACCEPT_SUIT_MAX_AGE default is 300 seconds or change this value to shorten the wait time)
- Attempt to approve a suit
- You will be forced to re-authenticate
- Suit will be approved following re-authentication
- Create another suit
- Attempt to approve the suit within 5 minutes
- It should be accepted without re-authentication
## Who can review

Not @kentsanggds

Fixes https://trello.com/c/tzQmz89r
