### PR TITLE
enable app to connect to Azure AD account

### DIFF
--- a/app/blueprints/base/views.py
+++ b/app/blueprints/base/views.py
@@ -109,10 +109,17 @@ def oidc_callback():
 
     session["iat"] = user_info["iat"]
 
-    user = user_datastore.get_user(user_info['email'])
+    user = user_datastore.get_user(user_info.get(
+        'email', user_info.get('upn')))
 
     if not user:
         user = create_user(user_info)
+
+    user_name = getattr(user, 'name')
+    if user_name is None:
+        user_name = user_info.get('name')
+        user.name = user_name
+        db.session.commit()
 
     login_user(user)
 
@@ -126,7 +133,7 @@ def oidc_callback():
 
 
 def create_user(user_info):
-    email = user_info['email']
+    email = user_info.get('email', user_info.get('upn'))
 
     user = add_role('USER', user_datastore.create_user(
         email=email,

--- a/lib/oidc_old.py
+++ b/lib/oidc_old.py
@@ -147,7 +147,8 @@ class OIDC(object):
         response = request.send(config['token_endpoint'])
 
         if 'error' in response:
-            raise Exception(response['error'])
+            raise Exception(response['error'] + ", " +
+                            response.get("error_description"))
 
         return response
 
@@ -192,6 +193,8 @@ class TokenRequest(object):
         self._params = {
             'redirect_uri': redirect_uri,
             'code': code,
+            'client_id': client_id,
+            'client_secret': secret,
             'grant_type': grant_type}
 
     def send(self, token_endpoint):


### PR DESCRIPTION
## What
- enabled authentication and 2 factor authentication via Azure AD accounts
## How to review
- Set up Azure AD with accounts assigned to Sue My Brother app
- Log in with one of these Azure AD accounts
- 2 factor authentication is activated before access to app
- Clicking on reauthenticate on the Admin page will force user to re-enter password and activate 2 factor authentication
## Who can review

Not @kentsanggds

Fixes https://trello.com/c/NYpYgJTk
Partially fixes https://trello.com/c/Kqw4dAIP - cannot connect via Dex as Dex only parses 'email' key and not 'upn', and Dex does not process 'login=prompt' 
