### PR TITLE
Allow users to switch OIDC provider

### DIFF
--- a/app/blueprints/base/views.py
+++ b/app/blueprints/base/views.py
@@ -74,54 +74,41 @@ def authenticated_within(max_age):
 
 
 def force_authentication(path=None):
-    request_path = '/'
+    request_path = url_for('base.index')
     if path is not None:
         request_path = path
     session["next_url"] = request_path
-    return redirect(oidc.login(get_oidc_provider(),
-                               force_reauthentication=True))
+    return redirect(oidc.login(get_idp(), force_reauthentication=True))
 
 
-def get_oidc_provider():
-    oidc_provider = request.cookies.get('oidc_provider')
-    if oidc_provider is None:
-        oidc_provider = oidc.oidc_providers()[0]
-
-    return oidc_provider
+def get_idp():
+    return oidc.get_current_provider()
 
 
-def set_oidc_provider_cookie(response, oidc_provider):
-    response.set_cookie('oidc_provider', oidc_provider)
+@base.route('/set_idp', methods=['GET', 'POST'])
+def set_idp():
+    idp = request.form["idp"]
+    caller = request.args.get('caller', url_for('base.index'))
 
+    after_this_request(oidc.set_current_provider(idp))
 
-@base.route('/switch_oidc_provider/<path:caller>', methods=['GET', 'POST'])
-def switch_oidc_provider(caller):
-    oidc_provider = request.form["oidc_provider"]
-
-    @after_this_request
-    def remember_oidc_provider(response):
-        set_oidc_provider_cookie(response, oidc_provider)
-
-        return response
-
-    return redirect(url_for(caller))
+    return redirect(caller)
 
 
 @base.route('/reauthenticate/')
-@base.route('/reauthenticate/<path:caller>')
-def reauthenticate(caller=None):
-    return force_authentication(caller)
+def reauthenticate():
+    return force_authentication(request.args.get('caller', None))
 
 
 @base.route('/login')
 def login():
-    "login redirects to OIDC provider: " + get_oidc_provider()
+    "login redirects to currently selected OIDC provider"
 
     next_url = sanitize_url(unquote(request.args.get('next', '')))
     if next_url:
         session['next_url'] = next_url
 
-    return redirect(oidc.login(get_oidc_provider()))
+    return redirect(oidc.login(get_idp()))
 
 
 @base.route('/logout')
@@ -134,7 +121,7 @@ def logout():
 @base.route('/oidc_callback')
 @oidc.callback
 def oidc_callback():
-    user_info = oidc.authenticate(get_oidc_provider(), request)
+    user_info = oidc.authenticate(get_idp(), request)
 
     session["iat"] = user_info["iat"]
 

--- a/app/blueprints/base/views.py
+++ b/app/blueprints/base/views.py
@@ -78,11 +78,7 @@ def force_authentication(path=None):
     if path is not None:
         request_path = path
     session["next_url"] = request_path
-    return redirect(oidc.login(get_idp(), force_reauthentication=True))
-
-
-def get_idp():
-    return oidc.get_current_provider()
+    return redirect(oidc.login(force_reauthentication=True))
 
 
 @base.route('/set_idp', methods=['GET', 'POST'])
@@ -108,7 +104,7 @@ def login():
     if next_url:
         session['next_url'] = next_url
 
-    return redirect(oidc.login(get_idp()))
+    return redirect(oidc.login())
 
 
 @base.route('/logout')
@@ -121,7 +117,7 @@ def logout():
 @base.route('/oidc_callback')
 @oidc.callback
 def oidc_callback():
-    user_info = oidc.authenticate(get_idp(), request)
+    user_info = oidc.authenticate()
 
     session["iat"] = user_info["iat"]
 

--- a/app/config.py
+++ b/app/config.py
@@ -48,6 +48,18 @@ OIDC_PROVIDERS = {
         'client_id': env.get('OIDC_CLIENT_ID'),
         'client_secret': env.get('OIDC_CLIENT_SECRET'),
         'redirect_uri': None
+    },
+    'azure_ad': {
+        'discovery_url': env.get('OIDC_ISSUER_1'),
+        'client_id': env.get('OIDC_CLIENT_ID_1'),
+        'client_secret': env.get('OIDC_CLIENT_SECRET_1'),
+        'redirect_uri': None
+    },
+    'google': {
+        'discovery_url': env.get('OIDC_ISSUER_2'),
+        'client_id': env.get('OIDC_CLIENT_ID_2'),
+        'client_secret': env.get('OIDC_CLIENT_SECRET_2'),
+        'redirect_uri': None
     }
 }
 

--- a/app/factory.py
+++ b/app/factory.py
@@ -6,7 +6,6 @@ Sue My Brother app factory class
 import os
 
 from flask import Flask, render_template, session
-from app.blueprints.base.views import get_oidc_provider
 from app.extensions import oidc
 
 
@@ -67,10 +66,11 @@ def register_context_processors(app):
     """
 
     def base_context_processor():
-        return {'asset_path': '/static/govuk_template/assets/',
-                'auth_time': session.get('iat'),
-                'curr_oidc_provider': get_oidc_provider,
-                'oidc_providers': oidc.oidc_providers()}
+        return {
+            'asset_path': '/static/govuk_template/assets/',
+            'auth_time': session.get('iat'),
+            'idp': oidc.get_current_provider,
+            'oidc_providers': oidc.providers()}
 
     app.context_processor(base_context_processor)
 

--- a/app/factory.py
+++ b/app/factory.py
@@ -6,6 +6,8 @@ Sue My Brother app factory class
 import os
 
 from flask import Flask, render_template, session
+from app.blueprints.base.views import get_oidc_provider
+from app.extensions import oidc
 
 
 def create_app(config='config.py', **kwargs):
@@ -66,7 +68,9 @@ def register_context_processors(app):
 
     def base_context_processor():
         return {'asset_path': '/static/govuk_template/assets/',
-                'auth_time': session.get('iat')}
+                'auth_time': session.get('iat'),
+                'curr_oidc_provider': get_oidc_provider,
+                'oidc_providers': oidc.oidc_providers()}
 
     app.context_processor(base_context_processor)
 

--- a/app/templates/admin/index.html
+++ b/app/templates/admin/index.html
@@ -21,9 +21,6 @@
     <h2 class="heading-medium flush--top">Notify options</h2>
     <a href="{{ config["GOVUK_NOTIFY"]["service_url"] }}/services/{{ config["GOVUK_NOTIFY"]["client_id"] }}/dashboard">Update email and sms templates</a>
   </div>
-  <div>
-    <a href="{{ url_for('base.reauthenticate', caller='admin') }}">Reauthenticate</a>
-  </div>
 
   <hr />
 

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -52,6 +52,18 @@
 
       {% block body_content %}{% endblock %}
 
+    <hr>
+    <div>
+      <form action="{{ url_for('base.switch_oidc_provider', caller=request.endpoint[4:]) }}" method="post">
+        OIDC provider: 
+        <select name="oidc_provider" onchange="this.form.submit()">
+          {% for key in oidc_providers %}
+          <option value="{{ key }}" {% if key==curr_oidc_provider() %}selected{% endif %}>{{ key.replace("_", " ").title() }}</option>
+          {% endfor %}
+        </select>
+        <a href="{{ url_for('base.reauthenticate', caller=request.path[1:]) }}">reauthenticate</a>
+      </form>
+    </div>
     </div>
   </main>
 {% endblock %}

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -54,14 +54,14 @@
 
     <hr>
     <div>
-      <form action="{{ url_for('base.switch_oidc_provider', caller=request.endpoint[4:]) }}" method="post">
+      <form action="{{ url_for('base.set_idp', caller=request.full_path) }}" method="post">
         OIDC provider: 
-        <select name="oidc_provider" onchange="this.form.submit()">
+        <select name="idp" onchange="this.form.submit()">
           {% for key in oidc_providers %}
-          <option value="{{ key }}" {% if key==curr_oidc_provider() %}selected{% endif %}>{{ key.replace("_", " ").title() }}</option>
+          <option value="{{ key }}" {% if key==idp() %}selected{% endif %}>{{ key.replace("_", " ").title() }}</option>
           {% endfor %}
         </select>
-        <a href="{{ url_for('base.reauthenticate', caller=request.path[1:]) }}">reauthenticate</a>
+        <a href="{{ url_for('base.reauthenticate', caller=request.full_path) }}">reauthenticate</a>
       </form>
     </div>
     </div>

--- a/lib/oidc_old.py
+++ b/lib/oidc_old.py
@@ -5,7 +5,7 @@ OIDC client Flask extension
 
 from urllib.parse import urlencode
 
-from flask import url_for, current_app
+from flask import url_for, current_app, request
 from jose import jwt
 import requests
 
@@ -48,8 +48,17 @@ class OIDC(object):
         self._callback_fn = fn
         return fn
 
-    def oidc_providers(self):
+    def providers(self):
         return list(self._config.keys())
+
+    def get_current_provider(self):
+        return request.cookies.get('idp', self.providers()[0])
+
+    def set_current_provider(self, idp):
+        def set_idp_cookie(response):
+            response.set_cookie('idp', idp)
+            return response
+        return set_idp_cookie
 
     @property
     def callback_url(self):

--- a/lib/oidc_old.py
+++ b/lib/oidc_old.py
@@ -99,12 +99,12 @@ class OIDC(object):
 
         return self._config[provider_name]
 
-    def login(self, provider_name, force_reauthentication=False):
+    def login(self, force_reauthentication=False):
         """
         Generate a login URL for a provider
         """
 
-        config = self.openid_config(provider_name)
+        config = self.openid_config(self.get_current_provider())
 
         kw = {}
         if force_reauthentication:
@@ -120,12 +120,12 @@ class OIDC(object):
 
         return auth_request.url(config['authorization_endpoint'])
 
-    def authenticate(self, provider_name, request):
+    def authenticate(self):
         """
         Authenticate a user and retrieve their userinfo
         """
 
-        config = self.openid_config(provider_name)
+        config = self.openid_config(self.get_current_provider())
         auth_code = request.args['code']
 
         token_response = self.token_request(config, auth_code)

--- a/lib/oidc_old.py
+++ b/lib/oidc_old.py
@@ -48,6 +48,9 @@ class OIDC(object):
         self._callback_fn = fn
         return fn
 
+    def oidc_providers(self):
+        return list(self._config.keys())
+
     @property
     def callback_url(self):
         """
@@ -147,8 +150,9 @@ class OIDC(object):
         response = request.send(config['token_endpoint'])
 
         if 'error' in response:
-            raise Exception(response['error'] + ", " +
-                            response.get("error_description"))
+            raise Exception('{error}, {description}'.format(
+                error=response['error'],
+                description=response.get('error_description')))
 
         return response
 

--- a/tests/test_change_oidc_provider.py
+++ b/tests/test_change_oidc_provider.py
@@ -1,0 +1,37 @@
+import pytest
+
+from flask import url_for
+
+
+def request(url, method, data=None):
+    r = method(url, data=data)
+    return r
+
+
+@pytest.fixture
+def post(client):
+
+    def submit(url):
+
+        def response(data):
+            return request(url, client.post, data=data)
+
+        return response
+
+    return submit
+
+
+@pytest.fixture
+def post_switch_oidc_provider(post):
+    return post(url_for('base.switch_oidc_provider', caller='.admin'))
+
+
+class WhenUserChangesOIDCProvider(object):
+
+    def it_stores_new_oidc_provider_in_cookie(self,
+                                              post_switch_oidc_provider):
+        data = {'oidc_provider': 'test'}
+        response = post_switch_oidc_provider(data)
+
+        cookies = response.headers.getlist('Set-Cookie')
+        assert any("oidc_provider=test;" in s for s in cookies)

--- a/tests/test_change_oidc_provider.py
+++ b/tests/test_change_oidc_provider.py
@@ -4,8 +4,7 @@ from flask import url_for
 
 
 def request(url, method, data=None):
-    r = method(url, data=data)
-    return r
+    return method(url, data=data)
 
 
 @pytest.fixture
@@ -22,16 +21,16 @@ def post(client):
 
 
 @pytest.fixture
-def post_switch_oidc_provider(post):
-    return post(url_for('base.switch_oidc_provider', caller='.admin'))
+def post_set_idp(post):
+    url = url_for('base.set_idp', caller='.admin')
+    return post(url)
 
 
 class WhenUserChangesOIDCProvider(object):
 
-    def it_stores_new_oidc_provider_in_cookie(self,
-                                              post_switch_oidc_provider):
-        data = {'oidc_provider': 'test'}
-        response = post_switch_oidc_provider(data)
+    def it_sets_idp(self, post_set_idp):
+        data = {'idp': 'test'}
+        response = post_set_idp(data)
 
         cookies = response.headers.getlist('Set-Cookie')
-        assert any("oidc_provider=test;" in s for s in cookies)
+        assert any("idp=test;" in s for s in cookies)

--- a/tests/test_oidc.py
+++ b/tests/test_oidc.py
@@ -108,9 +108,9 @@ def mock_requests_get(*args, **kwargs):
     if 'https://login.microsoftonline.com/testid' in args[0]:
         return MockResponse({
             'authorization_endpoint':
-            'https://login.microsoftonline.com/testid/oauth2/authorize',
+                'https://login.microsoftonline.com/testid/oauth2/authorize',
             'discovery_url':
-            'https://login.microsoftonline.com/testid'}, 200)
+                'https://login.microsoftonline.com/testid'}, 200)
     else:
         return MockResponse({}, 404)
 


### PR DESCRIPTION
## What
- enabled switching of OIDC provider from any page on the website
- store selection in cookie so that website remembers OIDC provider
## How to review
- change the OIDC provider on the drop down near the footer
- click on reauthenticate to go to chosen OIDC provider
## Who can review

Not @kentsanggds

https://trello.com/c/JYL1B4yq
